### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
 
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 25
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Neiland85-Org/elfosoftware-demo-flota-transportistes/security/code-scanning/6](https://github.com/Neiland85-Org/elfosoftware-demo-flota-transportistes/security/code-scanning/6)

The best way to fix this problem is to add an explicit `permissions:` block for the `build-test` job to restrict the GITHUB_TOKEN's access to only the minimal required scopes. Since the job only needs to checkout code (and not push, create PRs, or modify repository contents), `contents: read` is an appropriate minimal starting point. This is to be added under the `build-test:` job definition (just after `runs-on`, or possibly after `timeout-minutes: 25` for consistency). No other changes are necessary elsewhere, as all tool steps and jobs are otherwise unaffected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
