### PR TITLE
fix: resolve security scanning alert for missing workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code
@@ -85,6 +87,9 @@ jobs:
 
   dependency-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     
     steps:
     - name: Checkout code
@@ -106,6 +111,8 @@ jobs:
 
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 25
 
     steps:


### PR DESCRIPTION
This PR fixes the security scanning alert by adding explicit permissions to all CI workflow jobs:

## Changes Made:
- **lint-and-test**: Added  permission
- **dependency-scan**: Added  and  permissions  
- **build-test**: Added  permission
- **security-scan**: Already had appropriate permissions

## Security Impact:
- Eliminates overly permissive default permissions
- Follows principle of least privilege
- Resolves GitHub Security Code Scanning alert #6

## Testing:
- All jobs maintain their required functionality
- No breaking changes to existing CI/CD pipeline
- Permissions are minimal but sufficient for each job's needs

Closes security alert for workflow permissions.