### PR TITLE
fix: resolve CodeQL 'no source code detected' error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,22 +67,34 @@ jobs:
       security-events: write
       contents: read
       actions: read
-    # Solo ejecutar si hay archivos de código detectables
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.changed_files, '.py') || contains(github.event.pull_request.changed_files, '.js') || contains(github.event.pull_request.changed_files, '.ts') || contains(github.event.pull_request.changed_files, '.java') || contains(github.event.pull_request.changed_files, '.go') || contains(github.event.pull_request.changed_files, '.cpp') || contains(github.event.pull_request.changed_files, '.c') || contains(github.event.pull_request.changed_files, '.cs') || contains(github.event.pull_request.changed_files, '.rb') || contains(github.event.pull_request.changed_files, '.php')) }}
+    # Solo ejecutar si hay archivos Python reales en el proyecto
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.changed_files, '.py')) }}
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       
+    - name: Check for Python files
+      id: check_python
+      run: |
+        if find . -name "*.py" -type f | grep -q .; then
+          echo "has_python=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_python=false" >> $GITHUB_OUTPUT
+        fi
+      
     - name: Initialize CodeQL
+      if: steps.check_python.outputs.has_python == 'true'
       uses: github/codeql-action/init@v3
       with:
         languages: python
         
     - name: Autobuild
+      if: steps.check_python.outputs.has_python == 'true'
       uses: github/codeql-action/autobuild@v3
       
     - name: Perform CodeQL Analysis
+      if: steps.check_python.outputs.has_python == 'true'
       uses: github/codeql-action/analyze@v3
 
   dependency-scan:


### PR DESCRIPTION
This PR fixes the CodeQL security scanning error that occurs when no Python source code exists in the project.

## Problem:
The security-scan job was failing with:


## Root Cause:
- The project is in early stages with no Python source code yet
- CodeQL was attempting to analyze Python files that don't exist
- The job condition was too broad, triggering on file extensions rather than actual code presence

## Solution:
Enhanced the `security-scan` job with:
- **File existence check**: Added a step to verify Python files actually exist before running CodeQL
- **Conditional execution**: All CodeQL steps now only run when Python files are present
- **Improved logic**: More precise conditions prevent unnecessary CodeQL execution

## Changes Made:
- Added `Check for Python files` step that sets output variable
- Modified all CodeQL steps to include `if: steps.check_python.outputs.has_python == 'true'`
- Maintained existing condition for PR file changes but added runtime validation

## Benefits:
- ✅ Eliminates CodeQL errors when no source code exists
- ✅ Reduces unnecessary CI resource usage
- ✅ Maintains security scanning when Python code is added
- ✅ No breaking changes to existing functionality

## Future-Ready:
When Python source code is added to the project, the security scanning will automatically activate and work correctly.

Resolves CodeQL analysis failure in early-stage projects.